### PR TITLE
parse: Allow use of the wildcard CA in Certificate section

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -118,11 +118,14 @@ func parseCertificateSection(in []byte) (*KRLCertificateSection, error) {
 	if err := ssh.Unmarshal(in, &header); err != nil {
 		return nil, fmt.Errorf("krl: while parsing certificate section header: %v", err)
 	}
-	ca, err := ssh.ParsePublicKey(header.CAKey)
-	if err != nil {
-		return nil, fmt.Errorf("krl: while parsing CA key: %v", err)
+	k := new(KRLCertificateSection)
+	if len(header.CAKey) > 0 {
+		ca, err := ssh.ParsePublicKey(header.CAKey)
+		if err != nil {
+			return nil, fmt.Errorf("krl: while parsing CA key: %v", err)
+		}
+		k.CA = ca
 	}
-	k := &KRLCertificateSection{CA: ca}
 	in = header.Rest
 	for len(in) > 0 {
 		var section krlCertificateSection


### PR DESCRIPTION
OpenSSH allows the use of an empty CA, known as the wildcard CA in a certificate section. When the empty CA is in a KRL, all subsections then apply for certs from any and all CAs.

This package already allows creation of a KRL with an empty CA, but fails to parse one without this change.